### PR TITLE
Remove arm64 JNA removal workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,6 @@ RUN mkdir --parents /tmp/xp; \
     cd /tmp/xp; \
     wget -O- "$XP_DISTRO_PATH" | tar --strip-components=1 -xz
 
-# old JNA library doesn't support the arrch64 platform, but the current elasticsearch version needs it. Fortunately, it's not essential and can be removed.
-RUN set -eux; \
-    dpkgArch=`uname -m`; \
-    echo `uname -m`; \
-    if [ "$dpkgArch" = "aarch64" ]; then \
-      rm -f /tmp/xp/lib/jna-4.1.0.jar; \
-    fi;
-
 ################################################################################
 # Build stage 2 (the actual XP image):
 ################################################################################


### PR DESCRIPTION
Ref enonic/xp#12134 (XP PR enonic/xp#12135).

XP bumps JNA `4.1.0` → `5.19.0`, which ships a native dispatch library for `aarch64`. JNA 4.1.0 had no arm64 native, so this image deleted `jna-4.1.0.jar` on aarch64 builds. With 5.19.0 that step is obsolete (and would no longer match the renamed `jna-5.19.0.jar` anyway), so the whole arch-conditional `RUN` block is removed.

⚠️ **Merge ordering:** this targets `master` (the 8.1.0-SNAPSHOT line). Only merge once the XP distro built for this branch ships JNA 5.19.0 (i.e. after enonic/xp#12135 is merged and released). The `7.x`/`8.0` branches still build XP versions that ship JNA 4.1.0 and must keep the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)